### PR TITLE
Change "version" of errbit dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
 	],
 	"require": {
 		"php": ">=5.3.0",
-		"flippa-official/errbit-php": "dev-master"
+		"flippa-official/errbit-php": "dev-master#b432716d29c2b4ada0f21ccc469ccb046bb60340"
 	},
 	"target-dir": "SumoCoders/SumoForkClass",
 	"autoload": {


### PR DESCRIPTION
The "new" version of sending the data to Errbit doesn't work for us, so revert back to older version.
